### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,5 @@
-interface LoadTextFile {
-  /**
-   * Returns a promise for the text content.
-   */
-  (filePath: string): Promise<string>
+/** @returns a promise for the text content */
+export function loadTextFile(path: string | Buffer | URL): Promise<string>
 
-  /**
-   * Returns the text content.
-   */
-  sync (filePath: string): string
-}
-
-declare const loadTextFile: LoadTextFile
-export = loadTextFile
+/** @returns the text content */
+export function loadTextFileSync(path: string | Buffer | URL): string

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
-const fs = require('graceful-fs')
-const stripBom = require('strip-bom')
-const pify = require('pify')
+import fs from 'graceful-fs'
+import stripBom from 'strip-bom'
 
-module.exports = (filePath) => pify(fs.readFile)(filePath, 'utf8').then(stripBom)
-module.exports.sync = (filePath) => stripBom(fs.readFileSync(filePath, 'utf8'))
+export async function loadTextFile (path) {
+  return stripBom(await fs.promises.readFile(path, 'utf8'))
+}
+
+export function loadTextFileSync (path) {
+  return stripBom(fs.readFileSync(path, 'utf8'))
+}

--- a/package.json
+++ b/package.json
@@ -3,19 +3,21 @@
   "version": "1.2.0",
   "license": "MIT",
   "repository": "LinusU/load-text-file",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "test": "standard && node test"
+    "test": "standard && node test && ts-readme-generator --check"
   },
   "dependencies": {
-    "graceful-fs": "^4.0.0",
-    "pify": "^3.0.0 || ^4.0.0",
-    "strip-bom": "^3.0.0"
+    "graceful-fs": "^4.2.8",
+    "strip-bom": "^5.0.0"
   },
   "devDependencies": {
-    "standard": "^12.0.1"
+    "standard": "^16.0.3",
+    "ts-readme-generator": "^0.6.1"
   },
   "engines": {
-    "node": ">=6"
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "keywords": [
     "file",

--- a/readme.md
+++ b/readme.md
@@ -11,23 +11,34 @@ npm install --save load-text-file
 ## Usage
 
 ```js
-const loadTextFile = require('load-text-file')
+import { loadTextFile } from 'load-text-file'
 
-loadTextFile('foo.txt').then((text) => {
-  console.log(text)
-  //=> Hello, World!
-})
+const text = await loadTextFile('foo.txt')
+console.log(text)
+//=> Hello, World!
+```
+
+### Sync
+
+```js
+import { loadTextFileSync } from 'load-text-file'
+
+const text = loadTextFileSync('foo.txt')
+console.log(text)
+//=> Hello, World!
 ```
 
 ## API
 
-### loadTextFile(filePath)
+### `loadTextFile(path)`
 
-Returns a promise for the text content.
+- `path` (`string | Buffer | URL`, required)
+- returns `Promise<string>` - a promise for the text content
 
-### loadTextFile.sync(filepath)
+### `loadTextFileSync(path)`
 
-Returns the text content.
+- `path` (`string | Buffer | URL`, required)
+- returns `string` - the text content
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -1,12 +1,14 @@
-const assert = require('assert')
-const loadTextFile = require('./')
-const fs = require('fs')
+import assert from 'node:assert'
+import fs from 'node:fs'
 
-assert.strictEqual(loadTextFile.sync('index.js'), fs.readFileSync('index.js').toString())
+import { loadTextFile, loadTextFileSync } from './index.js'
 
-loadTextFile('index.js').then((text) => {
-  assert.strictEqual(text, fs.readFileSync('index.js').toString())
-}).catch((err) => {
+async function main () {
+  assert.strictEqual(await loadTextFile('index.js'), fs.readFileSync('index.js').toString())
+  assert.strictEqual(loadTextFileSync('index.js'), fs.readFileSync('index.js').toString())
+}
+
+main().catch((error) => {
   process.exitCode = 1
-  console.error(err.stack)
+  console.error(error.stack)
 })


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`